### PR TITLE
Do not populate repeater fields in admin with SEO form + Update translations' handling code

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -28,6 +28,10 @@ class Plugin extends PluginBase
     private function addFormFields()
     {
         Event::listen('backend.form.extendFieldsBefore', function (Form $form) {
+            if ($form->isNested) {
+                return;
+            }
+                        
             $theme = Theme::getEditTheme();
 
             if (!$theme) {

--- a/components/Seo.php
+++ b/components/Seo.php
@@ -81,7 +81,6 @@ class Seo extends ComponentBase
             } else {
                 $this->canonicalUrl = Request::url();
             }            
-            $this->canonicalUrl = $post->seo_canonical_url ?? Request::url();
             $this->redirectUrl = $post->seo_redirect_url;
             $this->robotsIndex = $post->seo_robots_index;
             $this->robotsFollow = $post->seo_robots_follow;

--- a/components/Seo.php
+++ b/components/Seo.php
@@ -73,17 +73,18 @@ class Seo extends ComponentBase
 
             $this->title = $post->title;
             $this->description = $post->excerpt;
-            $this->keywords = $post->seo_keywords;
+            $this->keywords = $post->seo_keywords;       
+            $this->redirectUrl = $post->seo_redirect_url;
+            $this->robotsIndex = $post->seo_robots_index;
+            $this->robotsFollow = $post->seo_robots_follow;
+
             // The seo_canonical_url saves empty anyway so we need to check 
             // for it instead of relying on its (non)existence
             if ( !empty($post->seo_canonical_url) ) {
                 $this->canonicalUrl = $post->seo_canonical_url;
             } else {
                 $this->canonicalUrl = Request::url();
-            }            
-            $this->redirectUrl = $post->seo_redirect_url;
-            $this->robotsIndex = $post->seo_robots_index;
-            $this->robotsFollow = $post->seo_robots_follow;
+            }
 
             $featuredImage = $post->featured_images->first();
             if ($featuredImage) {
@@ -112,8 +113,9 @@ class Seo extends ComponentBase
                 $url = substr($url, 3); 
 
                 // If we're in root then use root as URL
-                if (!strlen($url))
+                if (!strlen($url)) {
                     $url = '/';
+                }
             }
 
             $router = new Router(Theme::getActiveTheme());
@@ -126,12 +128,12 @@ class Seo extends ComponentBase
             // Updated to reflect change from $page->getViewBag() to $page->viewBag 
             // which is an array now
             $this->title = $viewBag['meta_title'] ?? $viewBag['title'];
-            $this->description = $viewBag['meta_description'] ?? NULL;
-            $this->keywords = $viewBag['seo_keywords'] ?? NULL;
+            $this->description = $viewBag['meta_description'] ?? null;
+            $this->keywords = $viewBag['seo_keywords'] ?? null;
             $this->canonicalUrl = $viewBag['seo_canonical_url'] ?? Request::url();
-            $this->redirectUrl = $viewBag['seo_redirect_url'] ?? NULL;
-            $this->robotsIndex = $viewBag['seo_robots_index'] ?? NULL;
-            $this->robotsFollow = $viewBag['seo_robots_follow'] ?? NULL;
+            $this->redirectUrl = $viewBag['seo_redirect_url'] ?? null;
+            $this->robotsIndex = $viewBag['seo_robots_index'] ?? null;
+            $this->robotsFollow = $viewBag['seo_robots_follow'] ?? null;
         }
     }
 

--- a/components/Seo.php
+++ b/components/Seo.php
@@ -74,6 +74,13 @@ class Seo extends ComponentBase
             $this->title = $post->title;
             $this->description = $post->excerpt;
             $this->keywords = $post->seo_keywords;
+            // The seo_canonical_url saves empty anyway so we need to check 
+            // for it instead of relying on its (non)existence
+            if ( !empty($post->seo_canonical_url) ) {
+                $this->canonicalUrl = $post->seo_canonical_url;
+            } else {
+                $this->canonicalUrl = Request::url();
+            }            
             $this->canonicalUrl = $post->seo_canonical_url ?? Request::url();
             $this->redirectUrl = $post->seo_redirect_url;
             $this->robotsIndex = $post->seo_robots_index;
@@ -100,22 +107,32 @@ class Seo extends ComponentBase
             // If RainLab.Translate plugin is installed we need to ensure, that
             // lang prefix is not in our way, so we are removing it from url.
             if (PluginManager::instance()->hasPlugin('RainLab.Translate')) {
-                if (Str::contains($url, '/')) {
-                    $url = explode('/', $url)[1];
-                }
+                // Remove language prefix from URL to get clean URL
+                // Simply exploding the URL after first slash does not work for 
+                // multilevel websites
+                $url = substr($url, 3); 
+
+                // If we're in root then use root as URL
+                if (!strlen($url))
+                    $url = '/';
             }
 
             $router = new Router(Theme::getActiveTheme());
             $page = $router->findByUrl($url);
-            $viewBag = $page->getViewBag();
+            // Proper way of obtaining localized/translated viewBag data from 
+            // Static page. According to documentation the getViewBag() method 
+            // is for internal use only.
+            $viewBag = $page->viewBag;
 
-            $this->title = $viewBag->meta_title ?? $viewBag->title;
-            $this->description = $viewBag->meta_description;
-            $this->keywords = $viewBag->seo_keywords;
-            $this->canonicalUrl = $viewBag->seo_canonical_url ?? Request::url();
-            $this->redirectUrl = $viewBag->seo_redirect_url;
-            $this->robotsIndex = $viewBag->seo_robots_index;
-            $this->robotsFollow = $viewBag->seo_robots_follow;
+            // Updated to reflect change from $page->getViewBag() to $page->viewBag 
+            // which is an array now
+            $this->title = $viewBag['meta_title'] ?? $viewBag['title'];
+            $this->description = $viewBag['meta_description'] ?? NULL;
+            $this->keywords = $viewBag['seo_keywords'] ?? NULL;
+            $this->canonicalUrl = $viewBag['seo_canonical_url'] ?? Request::url();
+            $this->redirectUrl = $viewBag['seo_redirect_url'] ?? NULL;
+            $this->robotsIndex = $viewBag['seo_robots_index'] ?? NULL;
+            $this->robotsFollow = $viewBag['seo_robots_follow'] ?? NULL;
         }
     }
 


### PR DESCRIPTION
If a Static page layout extends form fields of a page with a repeater field then fields included in the repeater are also populated with the SEO fields from this plugin. The code needs to detect the level of form fields and stop populating its forms if deeper than first level.

Fix for Issue #2 in original repo.